### PR TITLE
Add Table.ColumWidth getter function

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -287,6 +287,15 @@ func (t *Table) Select(id TableCellID) {
 	}
 }
 
+// ColumnWidth returns the column width, if set.
+func (t *Table) ColumnWidth(id int) (width float32, ok bool) {
+	if t.columnWidths == nil {
+		return
+	}
+	width, ok = t.columnWidths[id]
+	return
+}
+
 // SetColumnWidth supports changing the width of the specified column. Columns normally take the width of the template
 // cell returned from the CreateCell callback. The width parameter uses the same units as a fyne.Size type and refers
 // to the internal content width not including the divider size.

--- a/widget/table_internal_test.go
+++ b/widget/table_internal_test.go
@@ -746,6 +746,35 @@ func TestTable_Select(t *testing.T) {
 	assert.Equal(t, 4, selectedRow)
 }
 
+func TestTable_ColumnWidth(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	table := NewTable(
+		func() (int, int) { return 5, 5 },
+		func() fyne.CanvasObject {
+			return NewLabel("placeholder")
+		},
+		func(id TableCellID, obj fyne.CanvasObject) {
+			if id.Col == 0 {
+				obj.(*Label).Text = "p"
+			} else {
+				obj.(*Label).Text = "placeholder"
+			}
+			obj.Refresh()
+		})
+
+	width, ok := table.ColumnWidth(0)
+	assert.False(t, ok)
+	assert.Equal(t, float32(0), width)
+
+	table.SetColumnWidth(0, 32)
+
+	width, ok = table.ColumnWidth(0)
+	assert.True(t, ok)
+	assert.Equal(t, float32(32), width)
+}
+
 func TestTable_SetColumnWidth(t *testing.T) {
 	test.NewTempApp(t)
 	test.ApplyTheme(t, test.Theme())


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Added ColumWidth function to Table that returns the column width, if set by SetColumnWidth.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
